### PR TITLE
Bugfix: handle more than one document

### DIFF
--- a/mendeley_add_citations.py
+++ b/mendeley_add_citations.py
@@ -84,7 +84,7 @@ print('Tags are added immediately. You can interrupt the script and continue lat
 
 print('citations\tyear\tMendeley library title')
 num_skipped = 0
-documents = mendeley.library(items=-1)
+documents = mendeley.library(items=1000)
 scholar = ScholarQuerier(count=1)
 
 for docid in documents['document_ids']:


### PR DESCRIPTION
Hello there!
First, thanks for this library. It makes my life easier.
I've noticed that Mendeley, when asked for '-1' documents, doesn't return the full list of documents in the library anymore (as they have implemented paging).
I'm attaching a super-quick fix, that downloads 1k documents at once, although the correct fix should be to handle paging, so that people trying out your awesome code can see it working.

Ciao!
