### PR TITLE
Solves Google Block HTTP 503

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ On the first run you will be asked to go to an url where you have to grant acces
 You can set a few options at the beginning of `mendeley-add-citations.py`.
 
 The whole process takes from **tens of minutes** to **hours**. There are 
-pauses between requests to Google Scholar between 5 and 20 seconds to avoid being blocked
+pauses between requests to Google Scholar between 15 and 30 seconds to avoid being blocked
 by Google.
 
 Known Problems

--- a/mendeley_add_citations.py
+++ b/mendeley_add_citations.py
@@ -113,6 +113,7 @@ def process(document):
     if save_cookie:
         query.set_phrase("quantum theory")
         scholar.send_query(query)
+        scholar.save_cookies()
         save_cookie = False
 
     query.set_phrase(document.title)
@@ -129,6 +130,7 @@ def process(document):
     old_tags = document.tags
     citation_tag = ncitations_to_tag(scholar_articles[0]['num_citations'])
     new_tags = update_tags(old_tags, [(tag_pattern, citation_tag)])
+    new_tags.append(str(scholar_articles[0]['num_citations']))
     document.update(tags=new_tags)
     
     return scholar_articles[0]['num_citations']

--- a/mendeley_add_citations.py
+++ b/mendeley_add_citations.py
@@ -23,9 +23,12 @@ import yaml
 # skip documents already processed
 skip_documents = True
 
+# save cookie in init
+save_cookie = True
+
 # min and max sleep time in seconds between Scholar requests
-min_sleep_time_sec = 5
-max_sleep_time_sec = 20
+min_sleep_time_sec = 10
+max_sleep_time_sec = 30
 
 # minimal difflib.SequenceMatcher ratio for 
 # Mendeley x Scholar title matching 
@@ -101,9 +104,17 @@ def has_citation_tag(tags, patterns):
     return False
 
 
-def process(document):        
+def process(document):
     scholar = ScholarQuerier() 
     query = SearchScholarQuery()
+
+    # save cookie at first paper
+    global save_cookie
+    if save_cookie:
+        query.set_phrase("quantum theory")
+        scholar.send_query(query)
+        save_cookie = False
+
     query.set_phrase(document.title)
     scholar.send_query(query)
     scholar_articles = scholar.articles
@@ -167,8 +178,7 @@ def add_citations():
     mendeley_session = get_session_from_cookies()
     if 'process_id' not in session or 'ids' not in user_data:
         session['process_id'] = 0
-        user_data['ids'] = [doc.id for doc in mendeley_session.documents.iter()]       
-    
+        user_data['ids'] = [doc.id for doc in mendeley_session.documents.iter()]
     if skip_documents:
         while True:
             document = mendeley_session.documents.get(

--- a/scholar/scholar.py
+++ b/scholar/scholar.py
@@ -249,7 +249,7 @@ class ScholarConf(object):
 
     # If set, we will use this file to read/save cookies to enable
     # cookie use across sessions.
-    COOKIE_JAR_FILE = None
+    COOKIE_JAR_FILE = 'scholar-cookies.txt'
 
 class ScholarUtils(object):
     """A wrapper for various utensils that come in handy."""
@@ -1307,8 +1307,8 @@ scholar.py -c 5 -a "albert einstein" -t --none "quantum theory" --after 1970"""
     else:
         txt(querier, with_globals=options.txt_globals)
 
-    if options.cookie_file:
-        querier.save_cookies()
+    # if options.cookie_file:
+    querier.save_cookies()
 
     return 0
 


### PR DESCRIPTION
Solves #4 

Added cookie support. By default it uses cookies always but can be configures to use it from config later.
I also increased wait time between papers, which can be reversed.
Also added actual citation numbers to tags since I wanted to see them.
